### PR TITLE
Null geom tests

### DIFF
--- a/types/null/sf_point.go
+++ b/types/null/sf_point.go
@@ -80,18 +80,6 @@ func (p *SFPoint) Set(v types.SFPoint) {
 	p.Valid = true
 }
 
-// SetCoords will set the coordinates of p. If the coordinates are invalid, the
-// SFPoint will contain no valid value, and an error will be returned.
-func (p *SFPoint) SetCoords(c ...float64) error {
-	_, err := p.Point.SetCoords(c)
-	if err != nil {
-		return err
-	}
-
-	p.Valid = true
-	return nil
-}
-
 // Null will set p to null; p.Valid will be false, and p.Point will contain no
 // meaningful value.
 func (p *SFPoint) Null() {

--- a/types/null/sf_point.go
+++ b/types/null/sf_point.go
@@ -90,7 +90,7 @@ func (p *SFPoint) Null() {
 // Interfaces
 
 // IsNil implements the pyrrho/encoding IsNiler interface. It will return true
-// if j is null.
+// if p is null.
 func (p SFPoint) IsNil() bool {
 	return !p.Valid
 }

--- a/types/null/sf_point_test.go
+++ b/types/null/sf_point_test.go
@@ -29,35 +29,32 @@ func TestSFPointCtors(t *testing.T) {
 	require := require.New(t)
 
 	// null.NullSFPoint returns a new null null.SFPoint.
-	// This is equivalwent to null.SFPoint{}.
-	pa := null.NullSFPoint()
-	require.False(pa.Valid)
+	// This is equivalent to null.SFPoint{}.
+	na := null.NullSFPoint()
+	require.False(na.Valid)
 
 	// Passing a nil types.SFPoint to null.NewSFPoint does the same thing.
-	pb := null.NewSFPoint(types.SFPoint{})
-	require.False(pb.Valid)
+	nb := null.NewSFPoint(types.SFPoint{})
+	require.False(nb.Valid)
 
 	// Passing a non-nil types.SFPoint constructs a new, valid null.SFPoint.
-	pc := null.NewSFPoint(testSFPointXY)
-	require.True(pc.Valid)
-	require.Equal(testSFPointXY, pc.Point)
+	pa := null.NewSFPoint(testSFPointXY)
+	require.True(pa.Valid)
+	require.Equal(testSFPointXY, pa.Point)
 
 	// You can also create null.SFPoints by passing coordinates.
-	pd := null.NewSFPointXY(1.2, 2.3)
-	require.Equal(testSFPointXY, pd.Point)
+	pb := null.NewSFPointXY(1.2, 2.3)
+	require.Equal(testSFPointXY, pb.Point)
 
-	pe := null.NewSFPointXYZ(1.2, 2.3, 3.4)
-	require.Equal(testSFPointXYZ, pe.Point)
+	pc := null.NewSFPointXYZ(1.2, 2.3, 3.4)
+	require.Equal(testSFPointXYZ, pc.Point)
 }
 
 func TestSFPointValueOrZero(t *testing.T) {
 	require := require.New(t)
 
-	pa := null.NewSFPoint(testSFPointXY)
-	require.EqualValues(testSFPointXY, pa.ValueOrZero())
-
-	pb := null.NewSFPoint(testSFPointXYZ)
-	require.EqualValues(testSFPointXYZ, pb.ValueOrZero())
+	p := null.NewSFPoint(testSFPointXY)
+	require.EqualValues(testSFPointXY, p.ValueOrZero())
 
 	n := null.SFPoint{}
 	require.EqualValues(types.SFPoint{}, n.ValueOrZero())

--- a/types/null/sf_point_test.go
+++ b/types/null/sf_point_test.go
@@ -1,0 +1,190 @@
+package null_test
+
+import (
+	"database/sql/driver"
+	"encoding/json"
+	"testing"
+
+	"github.com/stretchr/testify/require"
+
+	"github.com/pyrrho/encoding/maps"
+	"github.com/pyrrho/encoding/types"
+	"github.com/pyrrho/encoding/types/null"
+)
+
+var (
+	testSFPointXY  = types.NewSFPointXY(1.2, 2.3)
+	testSFPointXYZ = types.NewSFPointXYZ(1.2, 2.3, 3.4)
+	// WKB representation of the XY test point.
+	testPointXYWKB = []byte{
+		0x01, 0x01, 0x00, 0x00, 0x00, 0x33, 0x33, 0x33,
+		0x33, 0x33, 0x33, 0xf3, 0x3f, 0x66, 0x66, 0x66,
+		0x66, 0x66, 0x66, 0x02, 0x40,
+	}
+	// GeoJSON representation of the XY test point.
+	testPointXYGeoJSON = []byte(`{"type":"Point","coordinates":[1.2,2.3]}`)
+)
+
+func TestSFPointCtors(t *testing.T) {
+	require := require.New(t)
+
+	// null.NullSFPoint returns a new null null.SFPoint.
+	// This is equivalwent to null.SFPoint{}.
+	pa := null.NullSFPoint()
+	require.False(pa.Valid)
+
+	// Passing a nil types.SFPoint to null.NewSFPoint does the same thing.
+	pb := null.NewSFPoint(types.SFPoint{})
+	require.False(pb.Valid)
+
+	// Passing a non-nil types.SFPoint constructs a new, valid null.SFPoint.
+	pc := null.NewSFPoint(testSFPointXY)
+	require.True(pc.Valid)
+	require.Equal(testSFPointXY, pc.Point)
+
+	// You can also create null.SFPoints by passing coordinates.
+	pd := null.NewSFPointXY(1.2, 2.3)
+	require.Equal(testSFPointXY, pd.Point)
+
+	pe := null.NewSFPointXYZ(1.2, 2.3, 3.4)
+	require.Equal(testSFPointXYZ, pe.Point)
+}
+
+func TestSFPointValueOrZero(t *testing.T) {
+	require := require.New(t)
+
+	pa := null.NewSFPoint(testSFPointXY)
+	require.EqualValues(testSFPointXY, pa.ValueOrZero())
+
+	pb := null.NewSFPoint(testSFPointXYZ)
+	require.EqualValues(testSFPointXYZ, pb.ValueOrZero())
+
+	n := null.SFPoint{}
+	require.EqualValues(types.SFPoint{}, n.ValueOrZero())
+}
+
+func TestSFPointSet(t *testing.T) {
+	require := require.New(t)
+
+	p := null.SFPoint{}
+
+	p.Set(testSFPointXY)
+	require.True(p.Valid)
+	require.EqualValues(testSFPointXY, p.ValueOrZero())
+
+	p.Set(types.SFPoint{})
+	require.False(p.Valid)
+
+	p.Set(testSFPointXYZ)
+	require.True(p.Valid)
+	require.EqualValues(testSFPointXYZ, p.ValueOrZero())
+}
+
+func TestSFPointNull(t *testing.T) {
+	require := require.New(t)
+
+	p := null.NewSFPointXY(1.2, 2.3)
+
+	p.Null()
+	require.False(p.Valid)
+}
+
+func TestSFPointIsNil(t *testing.T) {
+	require := require.New(t)
+
+	p := null.NewSFPointXY(1.2, 2.3)
+	require.False(p.IsNil())
+
+	zero := null.NewSFPointXY(0.0, 0.0)
+	require.False(zero.IsNil())
+
+	empty := null.SFPoint{}
+	require.True(empty.IsNil())
+}
+
+func TestSFPointIsZero(t *testing.T) {
+	require := require.New(t)
+
+	p := null.NewSFPointXY(1.2, 2.3)
+	require.False(p.IsZero())
+
+	zero := null.NewSFPointXY(0.0, 0.0)
+	require.True(zero.IsZero())
+
+	empty := null.SFPoint{}
+	require.True(empty.IsZero())
+}
+
+func TestSFPointSQLValue(t *testing.T) {
+	require := require.New(t)
+	var val driver.Value
+	var err error
+
+	p := null.NewSFPointXY(1.2, 2.3)
+	val, err = p.Value()
+	require.NoError(err)
+	require.EqualValues(testPointXYWKB, val)
+}
+
+func TestSFPointSQLScan(t *testing.T) {
+	require := require.New(t)
+	var err error
+
+	var p null.SFPoint
+	err = p.Scan(driver.Value(testPointXYWKB))
+	require.NoError(err)
+	require.Equal(null.NewSFPoint(testSFPointXY), p)
+
+	var n null.SFPoint
+	err = n.Scan(driver.Value(nil))
+	require.NoError(err)
+	require.Equal(null.NullSFPoint(), n)
+}
+
+func TestSFPointMarshalJSON(t *testing.T) {
+	require := require.New(t)
+	var data []byte
+	var err error
+
+	p := null.NewSFPointXY(1.2, 2.3)
+	data, err = json.Marshal(p)
+	require.NoError(err)
+	require.EqualValues(testPointXYGeoJSON, data)
+	data, err = json.Marshal(&p)
+	require.NoError(err)
+	require.EqualValues(testPointXYGeoJSON, data)
+
+	n := null.SFPoint{}
+	data, err = json.Marshal(n)
+	require.NoError(err)
+	require.EqualValues("null", data)
+	data, err = json.Marshal(&n)
+	require.NoError(err)
+	require.EqualValues("null", data)
+}
+
+func TestSFPointUnmarshalJSON(t *testing.T) {
+	require := require.New(t)
+	var err error
+
+	var p null.SFPoint
+	err = json.Unmarshal(testPointXYGeoJSON, &p)
+	require.NoError(err)
+	require.EqualValues(null.NewSFPoint(testSFPointXY), p)
+}
+
+func TestSFPointMarshsalMapValue(t *testing.T) {
+	require := require.New(t)
+	type Wrapper struct{ Point null.SFPoint }
+	var wrapper Wrapper
+	var data map[string]interface{}
+	var err error
+
+	wrapper = Wrapper{null.NewSFPointXY(1.2, 2.3)}
+	data, err = maps.Marshal(wrapper)
+	require.NoError(err)
+	require.Equal(testSFPointXY, data["Point"])
+	data, err = maps.Marshal(&wrapper)
+	require.NoError(err)
+	require.Equal(testSFPointXY, data["Point"])
+}

--- a/types/null/sf_polygon.go
+++ b/types/null/sf_polygon.go
@@ -90,7 +90,7 @@ func (p *SFPolygon) Null() {
 // Interfaces
 
 // IsNil implements the pyrrho/encoding IsNiler interface. It will return true
-// if j is null.
+// if p is null.
 func (p SFPolygon) IsNil() bool {
 	return !p.Valid
 }

--- a/types/null/sf_polygon_test.go
+++ b/types/null/sf_polygon_test.go
@@ -259,8 +259,7 @@ func TestSFPolygonMarshsalMapValue(t *testing.T) {
 	var data map[string]interface{}
 	var err error
 
-	wrapper = Wrapper{
-		null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)}
+	wrapper = Wrapper{null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)}
 	data, err = maps.Marshal(wrapper)
 	require.NoError(err)
 	require.Equal(testSFPolygonXY, data["Polygon"])

--- a/types/null/sf_polygon_test.go
+++ b/types/null/sf_polygon_test.go
@@ -1,21 +1,22 @@
-package types_test
+package null_test
 
 import (
 	"database/sql/driver"
 	"encoding/json"
 	"testing"
 
-	"github.com/pyrrho/encoding/maps"
-	"github.com/pyrrho/encoding/types"
 	"github.com/stretchr/testify/require"
 	"github.com/twpayne/go-geom"
+
+	"github.com/pyrrho/encoding/maps"
+	"github.com/pyrrho/encoding/types"
+	"github.com/pyrrho/encoding/types/null"
 )
 
 var (
-	// These are all OpenGIS Simple Feature representations of the same
-	// XY Polygon, converted between representations with
+	// These are all OpenGIS Simple Feature representations of the XY test
+	// Polygon, converted between representations with
 	// https://rodic.fr/blog/online-conversion-between-geometric-formats/
-	testPolygonWKT     = []byte("POLYGON((30 10,40 40,20 40,10 20,30 10),(28 15,15 21,22 35,35 35,28 15))")
 	testPolygonGeoJSON = []byte(`{"type":"Polygon","coordinates":[[[30,10],[40,40],[20,40],[10,20],[30,10]],[[28,15],[15,21],[22,35],[35,35],[28,15]]]}`)
 	testPolygonWKB     = []byte{
 		0x01, 0x03, 0x00, 0x00, 0x00, 0x02, 0x00, 0x00,
@@ -72,132 +73,124 @@ var (
 			{28, 15},
 		},
 	}
-	testPolygonGoGeom = *geom.NewPolygon(geom.XY).MustSetCoords(testPolygonCoords)
-)
-
-func TestSFPolygonCtors(t *testing.T) {
-	require := require.New(t)
-
-	// types.SFPolygon is a wrapper around go-geom's Polygon class. As such,
-	// construction typically uses their conventions.
-	pa := types.NewSFPolygon(*geom.NewPolygon(geom.XY).MustSetCoords(
-		[][]geom.Coord{
-			{
-				{30, 10},
-				{40, 40},
-				{20, 40},
-				{10, 20},
-				{30, 10},
-			},
-			{
-				{28, 15},
-				{15, 21},
-				{22, 35},
-				{35, 35},
-				{28, 15},
-			},
-		}))
-	require.Equal(testPolygonCoords, pa.Coords())
-	require.Equal(testPolygonGoGeom, pa.Polygon)
-	// We have some helpers to make it easier, though.
-	pb := types.NewSFPolygonXY(
-		[][2]float64{
-			{30, 10},
-			{40, 40},
-			{20, 40},
-			{10, 20},
-			{30, 10},
-		},
-		[][2]float64{
-			{28, 15},
-			{15, 21},
-			{22, 35},
-			{35, 35},
-			{28, 15},
-		})
-	require.Equal(
-		*geom.NewPolygon(geom.XY).MustSetCoords(
-			[][]geom.Coord{
-				{
-					{30, 10},
-					{40, 40},
-					{20, 40},
-					{10, 20},
-					{30, 10},
-				},
-				{
-					{28, 15},
-					{15, 21},
-					{22, 35},
-					{35, 35},
-					{28, 15},
-				},
-			}),
-		pb.Polygon)
-	pc := types.NewSFPolygonXYZ([][3]float64{
+	testSFPolygonXY = types.NewSFPolygonXY(
+		testPolygonExternal,
+		testPolygonInternal)
+	// A different polygon to test the third dimension.
+	testSFPolygonXYZ = types.NewSFPolygonXYZ([][3]float64{
 		{30, 10, 1},
 		{40, 40, 2},
 		{20, 40, 3},
 		{10, 20, 4},
 		{30, 10, 5},
 	})
-	require.Equal(
-		*geom.NewPolygon(geom.XYZ).MustSetCoords(
-			[][]geom.Coord{{
-				{30, 10, 1},
-				{40, 40, 2},
-				{20, 40, 3},
-				{10, 20, 4},
-				{30, 10, 5},
-			}}),
-		pc.Polygon)
-}
-
-func TestSFPolygonIsNil(t *testing.T) {
-	require := require.New(t)
-
-	p := types.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
-	require.False(p.IsNil())
-
-	malformed := types.NewSFPolygonXY([][2]float64{
+	// A malformed test polygon.
+	testMalformedPolygon = types.NewSFPolygonXY([][2]float64{
 		{0.0, 0.0},
 		{0.0, 0.0},
 		{0.0, 0.0},
 		{0.0, 0.0},
 	})
+)
+
+func TestSFPolygonCtors(t *testing.T) {
+	require := require.New(t)
+
+	// null.NullSFPolygon returns a new null null.SFPolygon.
+	// This is equivalent to null.SFPolygon{}.
+	na := null.NullSFPolygon()
+	require.False(na.Valid)
+
+	// Passing a nil types.SFPolygon to null.NewSFPolygon does the same thing.
+	nb := null.NewSFPolygon(types.SFPolygon{})
+	require.False(nb.Valid)
+
+	pa := null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
+	require.True(pa.Valid)
+	require.Equal(testSFPolygonXY, pa.Polygon)
+
+	pb := null.NewSFPolygonXYZ([][3]float64{
+		{30, 10, 1},
+		{40, 40, 2},
+		{20, 40, 3},
+		{10, 20, 4},
+		{30, 10, 5},
+	})
+	require.True(pb.Valid)
+	require.Equal(testSFPolygonXYZ, pb.Polygon)
+}
+
+func TestSFPolygonValueOrZero(t *testing.T) {
+	require := require.New(t)
+
+	p := null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
+	require.EqualValues(testSFPolygonXY, p.ValueOrZero())
+
+	n := null.SFPolygon{}
+	require.EqualValues(types.SFPolygon{}, n.ValueOrZero())
+}
+
+func TestSFPolygonSet(t *testing.T) {
+	require := require.New(t)
+
+	p := null.SFPolygon{}
+
+	p.Set(testSFPolygonXY)
+	require.True(p.Valid)
+	require.EqualValues(testSFPolygonXY, p.ValueOrZero())
+
+	p.Set(types.SFPolygon{})
+	require.False(p.Valid)
+
+	p.Set(testMalformedPolygon)
+	require.True(p.Valid)
+	require.EqualValues(testMalformedPolygon, p.ValueOrZero())
+}
+
+func TestSFPolygonNull(t *testing.T) {
+	require := require.New(t)
+
+	p := null.NewSFPolygon(testSFPolygonXY)
+
+	p.Null()
+	require.False(p.Valid)
+}
+
+func TestSFPolygonIsNil(t *testing.T) {
+	require := require.New(t)
+
+	p := null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
+	require.False(p.IsNil())
+
+	malformed := null.NewSFPolygon(testMalformedPolygon)
 	require.False(malformed.IsNil())
 
-	zero := types.NewSFPolygonXY([][2]float64{})
-	require.True(zero.IsNil())
+	zero := null.NewSFPolygonXY([][2]float64{})
+	require.False(zero.IsNil())
 
-	nul := types.NewSFPolygonXY(nil)
-	require.True(nul.IsNil())
+	nul := null.NewSFPolygonXY(nil)
+	require.False(nul.IsNil())
 
-	empty := types.SFPolygon{}
+	empty := null.SFPolygon{}
 	require.True(empty.IsNil())
 }
 
 func TestSFPolygonIsZero(t *testing.T) {
 	require := require.New(t)
 
-	p := types.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
+	p := null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
 	require.False(p.IsZero())
 
-	malformed := types.NewSFPolygonXY([][2]float64{
-		{0.0, 0.0},
-		{0.0, 0.0},
-		{0.0, 0.0},
-		{0.0, 0.0},
-	})
+	malformed := null.NewSFPolygon(testMalformedPolygon)
 	require.True(malformed.IsZero())
 
-	zero := types.NewSFPolygonXY([][2]float64{})
+	zero := null.NewSFPolygonXY([][2]float64{})
 	require.True(zero.IsZero())
 
-	nul := types.NewSFPolygonXY(nil)
+	nul := null.NewSFPolygonXY(nil)
 	require.True(nul.IsZero())
 
-	empty := types.SFPolygon{}
+	empty := null.SFPolygon{}
 	require.True(empty.IsZero())
 }
 
@@ -206,7 +199,7 @@ func TestSFPolygonSQLValue(t *testing.T) {
 	var val driver.Value
 	var err error
 
-	p := types.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
+	p := null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
 	val, err = p.Value()
 	require.NoError(err)
 	require.EqualValues(testPolygonWKB, val)
@@ -216,14 +209,15 @@ func TestSFPolygonSQLScan(t *testing.T) {
 	require := require.New(t)
 	var err error
 
-	var p types.SFPolygon
+	var p null.SFPolygon
 	err = p.Scan(driver.Value(testPolygonWKB))
 	require.NoError(err)
-	require.Equal(testPolygonCoords, p.Coords())
+	require.Equal(null.NewSFPolygon(testSFPolygonXY), p)
 
-	var bad types.SFPolygon
-	err = bad.Scan(driver.Value(nil))
-	require.Error(err)
+	var n null.SFPolygon
+	err = n.Scan(driver.Value(nil))
+	require.NoError(err)
+	require.Equal(null.NullSFPolygon(), n)
 }
 
 func TestSFPolygonMarshalJSON(t *testing.T) {
@@ -231,7 +225,7 @@ func TestSFPolygonMarshalJSON(t *testing.T) {
 	var data []byte
 	var err error
 
-	p := types.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
+	p := null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)
 	data, err = json.Marshal(p)
 	require.NoError(err)
 	require.EqualValues(testPolygonGeoJSON, data)
@@ -239,36 +233,38 @@ func TestSFPolygonMarshalJSON(t *testing.T) {
 	require.NoError(err)
 	require.EqualValues(testPolygonGeoJSON, data)
 
-	bad := types.SFPolygon{}
-	_, err = json.Marshal(bad)
-	require.Error(err)
-	_, err = json.Marshal(&bad)
-	require.Error(err)
+	n := null.SFPolygon{}
+	data, err = json.Marshal(n)
+	require.NoError(err)
+	require.EqualValues("null", data)
+	data, err = json.Marshal(&n)
+	require.NoError(err)
+	require.EqualValues("null", data)
 }
 
 func TestSFPolygonUnmarshalJSON(t *testing.T) {
 	require := require.New(t)
 	var err error
 
-	var p types.SFPolygon
+	var p null.SFPolygon
 	err = json.Unmarshal(testPolygonGeoJSON, &p)
 	require.NoError(err)
-	require.Equal(testPolygonCoords, p.Coords())
+	require.Equal(null.NewSFPolygon(testSFPolygonXY), p)
 }
 
 func TestSFPolygonMarshsalMapValue(t *testing.T) {
 	require := require.New(t)
-	type Wrapper struct{ Polygon types.SFPolygon }
+	type Wrapper struct{ Polygon null.SFPolygon }
 	var wrapper Wrapper
 	var data map[string]interface{}
 	var err error
 
 	wrapper = Wrapper{
-		types.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)}
+		null.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)}
 	data, err = maps.Marshal(wrapper)
 	require.NoError(err)
-	require.Equal(types.NewSFPolygon(testPolygonGoGeom), data["Polygon"])
+	require.Equal(testSFPolygonXY, data["Polygon"])
 	data, err = maps.Marshal(&wrapper)
 	require.NoError(err)
-	require.Equal(types.NewSFPolygon(testPolygonGoGeom), data["Polygon"])
+	require.Equal(testSFPolygonXY, data["Polygon"])
 }

--- a/types/sf_point_test.go
+++ b/types/sf_point_test.go
@@ -5,11 +5,11 @@ import (
 	"encoding/json"
 	"testing"
 
-	"github.com/pyrrho/encoding/maps"
-
-	"github.com/pyrrho/encoding/types"
 	"github.com/stretchr/testify/require"
 	"github.com/twpayne/go-geom"
+
+	"github.com/pyrrho/encoding/maps"
+	"github.com/pyrrho/encoding/types"
 )
 
 var (

--- a/types/sf_polygon_test.go
+++ b/types/sf_polygon_test.go
@@ -263,8 +263,7 @@ func TestSFPolygonMarshsalMapValue(t *testing.T) {
 	var data map[string]interface{}
 	var err error
 
-	wrapper = Wrapper{
-		types.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)}
+	wrapper = Wrapper{types.NewSFPolygonXY(testPolygonExternal, testPolygonInternal)}
 	data, err = maps.Marshal(wrapper)
 	require.NoError(err)
 	require.Equal(types.NewSFPolygon(testPolygonGoGeom), data["Polygon"])


### PR DESCRIPTION
Add tests for null.SFPoint and null.SFPolygon. I took out the `SFPoint.SetCoords` method because it started to involve the `geom` library more than I'd like for this level of wrapping. It seems like the user could just `Set` a new `SFPoint` easily enough.