### PR TITLE
Swagger `strfmt`

### DIFF
--- a/types/null/string.go
+++ b/types/null/string.go
@@ -12,6 +12,7 @@ import (
 //
 // If the String is valid and contains the empty string, it will be considered
 // non-nil, and of zero value.
+// swagger:strfmt optional
 type String struct {
 	sql.NullString
 }
@@ -84,7 +85,7 @@ func (s String) MarshalJSON() ([]byte, error) {
 
 // UnmarshalJSON implements the encoding/json Unmarshaler interface. It will
 // decode a given []byte into s, so long as the provided []byte is a valid JSON
-//string or a null.
+// string or a null.
 //
 // An empty string will result in a valid-but-empty String. The keyword 'null'
 // will result in a null String. The string '"null"' is considered to be a

--- a/types/null/time.go
+++ b/types/null/time.go
@@ -13,6 +13,7 @@ import (
 //
 // If the Time is valid and contains the zero time instant, it will be
 // considered non-null, and of zero value.
+// swagger:strfmt date-time
 type Time struct {
 	Time  time.Time
 	Valid bool


### PR DESCRIPTION
Add Swagger annotations to types that marshal as strings so that they're represented correctly when generating API documentation. `date-time` is a well-known format; `optional` is custom and perhaps not entirely correct as it's supposed to be a "format", but it will generally show up as something like: `string<optional>`, which seems pretty clear. The other option would be something like `string<nullable>`.